### PR TITLE
Fix invalid datetime

### DIFF
--- a/app/src/components/recommended-card/recommended-card.js
+++ b/app/src/components/recommended-card/recommended-card.js
@@ -119,10 +119,10 @@ class RecommendedCard extends HTMLElement {
         this.querySelector("#rc-engine").innerText = this.info.engine;
         this.querySelector("#rc-status").innerText = this.info.status;
         this.querySelector("#rc-available-version").innerText = this.info.version;
-        this.querySelector("#rc-preview").setAttribute("src", this.info.previewSrc);
+        const preview = this.info.previewSrc ? this.info.previewSrc : this.DEFAULT_IMAGE;
+        this.querySelector("#rc-preview").setAttribute("src", preview);
         this.querySelector("#rc-tags").innerText = this.info.tags.join(", ");
-        const preview = this.info.url ? this.info.url : this.DEFAULT_IMAGE;
-        this.querySelector("#rc-open-thread-btn").setAttribute("href", preview);
+        this.querySelector("#rc-open-thread-btn").setAttribute("href", this.info.url);
 
         // Show/hide last update date
         const lastUpdateElement = this.querySelector("#rc-last-update");

--- a/app/src/components/recommended-card/recommended-card.js
+++ b/app/src/components/recommended-card/recommended-card.js
@@ -121,7 +121,8 @@ class RecommendedCard extends HTMLElement {
         this.querySelector("#rc-available-version").innerText = this.info.version;
         this.querySelector("#rc-preview").setAttribute("src", this.info.previewSrc);
         this.querySelector("#rc-tags").innerText = this.info.tags.join(", ");
-        this.querySelector("#rc-open-thread-btn").setAttribute("href", this.info.url);
+        const preview = this.info.url ? this.info.url : this.DEFAULT_IMAGE;
+        this.querySelector("#rc-open-thread-btn").setAttribute("href", preview);
 
         // Show/hide last update date
         const lastUpdateElement = this.querySelector("#rc-last-update");

--- a/package-lock.json
+++ b/package-lock.json
@@ -2537,9 +2537,9 @@
             }
         },
         "f95api": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/f95api/-/f95api-1.9.3.tgz",
-            "integrity": "sha512-l+WORsvz3+Ca5iWWj1nfnEhH+IE+6IW/qZh+D4rM4zARPZSUNU4+prXwq4rR1Y3ZIpg74yC+AyMH7uoPVV1ffw==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/f95api/-/f95api-1.9.4.tgz",
+            "integrity": "sha512-KRpzuDIl6QpsCj0nU9AmSWy3WxasMgMrRLnaWIfJMNq2g7yMoJQVOIK/7t5OFmT6W7ks0ZIQU+JbVlj6YV6pcQ==",
             "requires": {
                 "axios": "^0.21.0",
                 "axios-cookiejar-support": "^1.0.1",
@@ -2547,6 +2547,7 @@
                 "ky": "^0.25.0",
                 "ky-universal": "^0.8.2",
                 "log4js": "^6.3.0",
+                "luxon": "^1.25.0",
                 "tough-cookie": "^4.0.0"
             }
         },
@@ -3628,6 +3629,11 @@
             "requires": {
                 "yallist": "^4.0.0"
             }
+        },
+        "luxon": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+            "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
         },
         "make-dir": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "electron-log": "^4.3.0",
         "electron-online": "^1.0.0",
         "electron-store": "^6.0.1",
-        "f95api": "^1.9.3",
+        "f95api": "^1.9.4",
         "glob": "^7.1.6",
         "i18next": "^19.8.4",
         "i18next-electron-language-detector": "0.0.10",


### PR DESCRIPTION
Fixed #54 by updating F95API to 1.9.4
The error was caused by the failure to verify that the date conformed to the ISO 8601 standard. 
In the recommend-card component, when converting from date to string, an **invalid range exception** was thrown.