### PR TITLE
Devtools and menubar

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -113,6 +113,23 @@ ipcMain.handle("user-data", function ipcOnUserData() {
     return app.getPath("userData");
 });
 
+// Show the devtools
+ipcMain.on("show-devtools", function ipcOnShowDevTools() {
+    logger.info("Opening devtools");
+    mainWindow.webContents.openDevTools();
+});
+
+// Enable or disable the menubar
+ipcMain.on("allow-menubar", function ipcOnAllowMenuBar(e, args) {
+    logger.info(`Allow menubar: ${args[0]}`);
+
+    // Save the preference
+    store.set("menubar", args[0]);
+
+    // Show/hide the devtools for the main window
+    mainWindow.setMenuBarVisibility(args[0]);
+});
+
 //#region Recommendation engine
 /**
  * @private

--- a/app/electron/main/main-preload.js
+++ b/app/electron/main/main-preload.js
@@ -56,6 +56,8 @@ const validSendChannels = [
     "app-version",
     "user-data",
     "window-size",
+    "show-devtools",
+    "allow-menubar"
 ];
 
 //#region Error management

--- a/app/electron/main/main-renderer.js
+++ b/app/electron/main/main-renderer.js
@@ -42,6 +42,10 @@ document.querySelector("#settings-password-toggle").addEventListener("click", on
 
 document.querySelector("#settings-reset-update-cache-btn").addEventListener("click", onDeleteUpdateCache);
 
+document.querySelector("#settings-show-devtools-btn").addEventListener("click", onShowDevTools);
+
+document.querySelector("#settings-menubar-checkbox").addEventListener("change", onEnableMenuBar);
+
 document.querySelector("#settings-save-credentials-btn").addEventListener("click", onSaveCredentialsFromSettings);
 
 document.querySelector("#main-language-select").addEventListener("change", updateLanguage);
@@ -254,6 +258,21 @@ async function onDeleteUpdateCache() {
 
     const translation = await window.API.translate("MR update cache deleted");
     sendToastToUser("info", translation);
+}
+
+/**
+ * Used when the user click on the button to show the devtools.
+ */
+function onShowDevTools() {
+    window.API.send("show-devtools");
+}
+
+/**
+ * Enable or disable the menubar in production mode.
+ * @param {*} e 
+ */
+function onEnableMenuBar(e) {
+    window.API.send("allow-menubar", e.target.checked);
 }
 
 /**

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -93,6 +93,28 @@
                     Delete
                 </a>
             </div>
+            <div class="flex-row">
+                <p id="settings-show-devtools-description" class="localizable">
+                    Show the Chrome DevTools
+                </p>
+                <a class="waves-effect waves-light btn localizable neutral-button" id="settings-show-devtools-btn">
+                    <i class="material-icons md-developer_mode left"></i>
+                    Show
+                </a>
+            </div>
+            <div class="flex-row">
+                <p id="settings-enable-menubar-description" class="localizable">
+                    Enable the MenuBar
+                </p>
+                <div class="switch">
+                    <label>
+                        <span class="localizable" id="settings-menubar-switch-off">Off</span>
+                        <input type="checkbox" id="settings-menubar-checkbox">
+                        <span class="lever"></span>
+                        <span class="localizable" id="settings-menubar-switch-on">On</span>
+                    </label>
+                </div>
+            </div>
         </div>
 
         <h5 id="main-account-divider" class="localizable">

--- a/app/src/scripts/window-creator.js
+++ b/app/src/scripts/window-creator.js
@@ -63,13 +63,10 @@ module.exports.createMainWindow = function (onclose) {
         shell.openExternal(url);
     });
 
-    // Disable default menu
-    if (!isDev) w.window.setMenu(null);
-
     // Load the index.html of the app.
     const htmlPath = path.join(HTML_DIR, "index.html");
     w.window.loadFile(htmlPath);
-
+    
     return w;
 };
 
@@ -100,11 +97,8 @@ module.exports.createLoginWindow = function (parent, onclose) {
         onclose: onclose
     });
 
-    // Set window properties and disable default menu
-    if (!isDev) {
-        w.window.setResizable(false);
-        w.window.setMenu(null);
-    }
+    // Set window properties
+    if (!isDev) w.window.setResizable(false);
 
     // Load the html file
     const htmlPath = path.join(HTML_DIR, "login.html");
@@ -151,11 +145,8 @@ module.exports.createMessagebox = function (parent, args, onclose) {
         onclose: onclose
     });
 
-    // Set window properties and disable default menu
-    if (!isDev) {
-        w.window.setResizable(false);
-        w.window.setMenu(null);
-    }
+    // Set window properties
+    if (!isDev) w.window.setResizable(false);
 
     // Load the html file
     const htmlPath = path.join(HTML_DIR, "messagebox.html");
@@ -191,11 +182,8 @@ module.exports.createURLInputbox = function(parent, onclose) {
         onclose: onclose
     });
     
-    // Set window properties and disable default menu
-    if (!isDev) {
-        w.window.setResizable(false);
-        w.window.setMenu(null);
-    }
+    // Set window properties
+    if (!isDev) w.window.setResizable(false);
 
     // Load the html file
     const htmlPath = path.join(HTML_DIR, "url-input.html");
@@ -238,11 +226,8 @@ module.exports.createUpdateMessagebox = function (parent, args, onclose) {
         onclose: onclose
     });
 
-    // Set window properties and disable default menu
-    if (!isDev) {
-        w.window.setResizable(false);
-        w.window.setMenu(null);
-    }
+    // Set window properties
+    if (!isDev) w.window.setResizable(false);
 
     // Load the html file
     const htmlPath = path.join(HTML_DIR, "update-messagebox.html");
@@ -303,6 +288,10 @@ function createBaseWindow(options) {
             preload: options.preloadPath,
         },
     });
+
+    // Disable default menu
+    const enableMenuBar = store.has("menubar") ?? false;
+    w.setMenuBarVisibility(isDev || enableMenuBar);
 
     // Show the window when is fully loaded (set the listener)
     w.webContents.on("did-finish-load", () => w.show());

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -44,6 +44,9 @@
     --button-negative-color-focus: #C93131;
     --button-neutral-color: #0A66BB; /* Denim */
     --button-neutral-color-focus: #2979C3;
+
+    --switch-selected-main: #990000;
+    --switch-selected-secondary: #a52020;
 }
 
 /* Used to not highligh the non-input elements */

--- a/app/src/styles/main.css
+++ b/app/src/styles/main.css
@@ -92,6 +92,15 @@ li[id^="select-options"] {
   gap: 5px;
 }
 
+/* Set colors for the "on" switch */
+.switch label input[type=checkbox]:checked+.lever {
+  background-color: var(--switch-selected-secondary) !important;
+}
+
+.switch label input[type=checkbox]:checked+.lever:after {
+  background-color: var(--switch-selected-main) !important;
+}
+
 /*### Input selectors ###*/
 #search-game-name,
 #settings-username-txt,

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -98,6 +98,11 @@
     "main-application-divider": "Anwendung",
     "settings-reset-update-cache-description": "Löschen Sie den Update-Cache (er wird bei Bedarf neu erstellt)",
     "settings-reset-update-cache-btn": "Cache löschen",
-    "MR update cache deleted": "Der Update-Cache wurde gelöscht"
+    "MR update cache deleted": "Der Update-Cache wurde gelöscht",
+    "settings-show-devtools-description": "Chrome Developer Tools anzeigen",
+    "settings-show-devtools-btn": "Öffnen",
+    "settings-enable-menubar-description": "Aktivieren Sie das Entwicklermenü",
+    "settings-menubar-switch-off": "Deaktivieren",
+    "settings-menubar-switch-on": "Aktivieren"
   }
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -98,6 +98,11 @@
     "main-application-divider": "Application",
     "settings-reset-update-cache-description": "Delete the update cache (it will be recreated when needed)",
     "settings-reset-update-cache-btn": "Delete cache",
-    "MR update cache deleted": "The update cache has been cleared"
+    "MR update cache deleted": "The update cache has been cleared",
+    "settings-show-devtools-description": "Show the Chrome DevTools",
+    "settings-show-devtools-btn": "Open",
+    "settings-enable-menubar-description": "Enable the developer menu",
+    "settings-menubar-switch-off": "Disable",
+    "settings-menubar-switch-on": "Enable"
   }
 }

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -98,6 +98,11 @@
     "main-application-divider": "Solicitud",
     "settings-reset-update-cache-description": "Elimine la caché de actualización (se volverá a crear cuando sea necesario)",
     "settings-reset-update-cache-btn": "Eliminar caché",
-    "MR update cache deleted": "Se borró la caché de actualización"
+    "MR update cache deleted": "Se borró la caché de actualización",
+    "settings-show-devtools-description": "Mostrar herramientas para desarrolladores de Chrome",
+    "settings-show-devtools-btn": "Abre",
+    "settings-enable-menubar-description": "Habilita el menú de desarrollador",
+    "settings-menubar-switch-off": "Inhabilitar",
+    "settings-menubar-switch-on": "Habilitar"
   }
 }

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -98,6 +98,11 @@
     "main-application-divider": "Application",
     "settings-reset-update-cache-description": "Supprimez le cache de mise à jour (il sera recréé si nécessaire)",
     "settings-reset-update-cache-btn": "Supprimer le cache",
-    "MR update cache deleted": "Le cache de mise à jour a été effacé"
+    "MR update cache deleted": "Le cache de mise à jour a été effacé",
+    "settings-show-devtools-description": "Afficher les outils de développement Chrome",
+    "settings-show-devtools-btn": "Montrer",
+    "settings-enable-menubar-description": "Activer le menu développeur",
+    "settings-menubar-switch-off": "Désactiver",
+    "settings-menubar-switch-on": "Activer"
   }
 }

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -98,6 +98,11 @@
     "main-application-divider": "Applicazione",
     "settings-reset-update-cache-description": "Elimina la cache degli aggiornamenti (verrà ricreata quando necessario)",
     "settings-reset-update-cache-btn": "Elimina cache",
-    "MR update cache deleted": "Cache degli aggiornamenti eliminata"
+    "MR update cache deleted": "Cache degli aggiornamenti eliminata",
+    "settings-show-devtools-description": "Mostra gli strumenti di sviluppo di Chrome",
+    "settings-show-devtools-btn": "Apri",
+    "settings-enable-menubar-description": "Abilita il menu per sviluppatori",
+    "settings-menubar-switch-off": "Disabilita",
+    "settings-menubar-switch-on": "Abilita"
   }
 }

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -98,6 +98,11 @@
     "main-application-divider": "Toepassing",
     "settings-reset-update-cache-description": "Verwijder de updatecache (deze wordt indien nodig opnieuw aangemaakt)",
     "settings-reset-update-cache-btn": "Cache verwijderen",
-    "MR update cache deleted": "De updatecache is gewist"
+    "MR update cache deleted": "De updatecache is gewist",
+    "settings-show-devtools-description": "Toon Chrome-ontwikkelaarstools",
+    "settings-show-devtools-btn": "Tentoonstellen",
+    "settings-enable-menubar-description": "Schakel het ontwikkelaarsmenu in",
+    "settings-menubar-switch-off": "Uitschakelen",
+    "settings-menubar-switch-on": "Inschakelen"
   }
 }

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -98,6 +98,11 @@
     "main-application-divider": "Inscrição",
     "settings-reset-update-cache-description": "Exclua o cache de atualização (ele será recriado quando necessário)",
     "settings-reset-update-cache-btn": "Excluir cache",
-    "MR update cache deleted": "O cache de atualização foi limpo"
+    "MR update cache deleted": "O cache de atualização foi limpo",
+    "settings-show-devtools-description": "Mostrar ferramentas para desenvolvedores do Chrome",
+    "settings-show-devtools-btn": "Visão",
+    "settings-enable-menubar-description": "Ative o menu do desenvolvedor",
+    "settings-menubar-switch-off": "Desabilitar",
+    "settings-menubar-switch-on": "Habilitar"
   }
 }

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -98,6 +98,11 @@
     "main-application-divider": "заявка",
     "settings-reset-update-cache-description": "Удалите кеш обновлений (он будет воссоздан при необходимости)",
     "settings-reset-update-cache-btn": "Удалить кеш",
-    "MR update cache deleted": "Кэш обновлений очищен"
+    "MR update cache deleted": "Кэш обновлений очищен",
+    "settings-show-devtools-description": "Показать инструменты разработчика Chrome",
+    "settings-show-devtools-btn": "Посмотреть",
+    "settings-enable-menubar-description": "Включить меню разработчика",
+    "settings-menubar-switch-off": "Отключить",
+    "settings-menubar-switch-on": "включить"
   }
 }

--- a/resources/lang/zh.json
+++ b/resources/lang/zh.json
@@ -98,6 +98,11 @@
     "main-application-divider": "应用",
     "settings-reset-update-cache-description": "删除更新缓存（将在需要时重新创建）",
     "settings-reset-update-cache-btn": "删除缓存",
-    "MR update cache deleted": "更新缓存已清除"
+    "MR update cache deleted": "更新缓存已清除",
+    "settings-show-devtools-description": "显示Chrome开发者工具",
+    "settings-show-devtools-btn": "视图",
+    "settings-enable-menubar-description": "启用开发者菜单",
+    "settings-menubar-switch-off": "禁用",
+    "settings-menubar-switch-on": "启用"
   }
 }


### PR DESCRIPTION
Add options in the settings menu to open Chrome DevTools and the standard menubar in production mode.